### PR TITLE
Disable terminal paging

### DIFF
--- a/certbot-to-asa.py
+++ b/certbot-to-asa.py
@@ -107,6 +107,9 @@ def connect_asa():
         print("[INFO] Entered enable mode successfully.")
     else:
         print("[INFO] Already in enable mode.")
+    # Disable terminal paging
+    child.sendline("terminal pager 0")
+    child.expect("#", timeout=10)
     return child
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Disable terminal paging so that ASAs with multiple trustpoints don't timeout while waiting for paging. Resolves #2 